### PR TITLE
[Souscription/Absences]changement des dates d'absences et commande par défaut

### DIFF
--- a/src/controller/SubscriptionAdmin.hx
+++ b/src/controller/SubscriptionAdmin.hx
@@ -393,57 +393,6 @@ class SubscriptionAdmin extends controller.Controller
 		view.nav.push( 'subscriptions' );
 	}
 
-
-	/**
-		user can edit his absences.
-		The user can't change his absence number.
-	**/
-	/*@logged @tpl("form.mtt")
-	function doAbsences( subscription:db.Subscription ) {
-
-		var returnUrl = "/contractAdmin/subscriptions/"+subscription.catalog.id;
-		if( !subscription.catalog.hasAbsencesManagement() ) throw Error(returnUrl,"Pas de gestion des absences sur ce contrat");
-		
-		var absenceDistribs = subscription.getAbsentDistribs();
-		var possibleAbsences = subscription.getPossibleAbsentDistribs();
-		var now = Date.now().getTime();
-		possibleAbsences = possibleAbsences.filter(d -> d.orderEndDate.getTime() > now);
-		var lockedDistribs = absenceDistribs.filter( d -> d.orderEndDate.getTime() < now);	//absences that are not editable anymore
-		
-		var form = new sugoi.form.Form("subscriptionAbsences");		
-		var possibleAbsencesData = possibleAbsences.map( d -> { label : Formatting.hDate(d.date,true), value : d.id } );
-		for ( i in 0...subscription.getAbsencesNb() ) {
-			if( lockedDistribs.has(absenceDistribs[i]) ){
-				//absence cannot be modified anymore, too late !
-				form.addElement(new sugoi.form.elements.Html('absenceLocked',Formatting.dDate(absenceDistribs[i].date)+" (trop tard pour changer)","Je serai absent(e) le :"));
-			}else{
-				form.addElement(new sugoi.form.elements.IntSelect( "absentDistrib" + i, "Je serai absent(e) le :", possibleAbsencesData, absenceDistribs[i].id, true ));
-			}			
-		}
-		
-		if ( form.checkToken() ) {
-
-			try {
-				var absentDistribIds = lockedDistribs.map(d->d.id);
-				for ( i in 0...absenceDistribs.length ) {				
-					if(form.getElement('absentDistrib' + i)!=null){
-						absentDistribIds.push( form.getValueOf( 'absentDistrib' + i ) );	
-					}					
-				}
-				AbsencesService.updateAbsencesDates( subscription, absentDistribIds,true );				
-			} catch( error:Error ) {
-				throw Error( Web.getURI(), error.message );
-			}
-
-			throw Ok( returnUrl, 'Les dates d\'absences ont bien été mises à jour.' );
-		}
-
-		view.form = form;
-		view.text = '<b>${subscription.getAbsencesNb()}</b> absences autorisées dans la période du <b>${DateTools.format( subscription.catalog.absencesStartDate, "%d/%m/%Y" )}</b> au <b>${DateTools.format( subscription.catalog.absencesEndDate, "%d/%m/%Y")}</b>';
-		view.title = "Absences de "+subscription.user.getName()+" pour le contrat \""+subscription.catalog.name+"\"";
-		
-	}*/
-	
 	/**
 	 * inserts a payment for a CSA contract
 	 */

--- a/src/controller/api/Catalog.hx
+++ b/src/controller/api/Catalog.hx
@@ -54,11 +54,11 @@ class Catalog extends Controller
     public function doSubscriptionAbsences(sub:db.Subscription){
 
 		if ( !app.user.canManageContract(sub.catalog) && !(app.user.id==sub.user.id) ){
-			throw new Error(403,t._('Access forbidden') );
+			throw new Error(Forbidden,t._('Access forbidden') );
 		} 
 		
 		if( !sub.catalog.hasAbsencesManagement() ) {
-			throw new Error(403,t._('no absences management in this catalog') );
+			throw new Error(Forbidden,t._('no absences management in this catalog') );
 		}
 		
 		var absenceDistribs = sub.getAbsentDistribs();
@@ -74,7 +74,7 @@ class Catalog extends Controller
             */
             var newAbsentDistribIds:Array<Int> = Json.parse(StringTools.urlDecode(post)).absentDistribIds;
             if (newAbsentDistribIds==null || newAbsentDistribIds.length==0) {
-                throw new Error(500,"bad parameter");
+                throw new Error(BadRequest,"bad parameter");
             }
             
             AbsencesService.updateAbsencesDates( sub, newAbsentDistribIds, false );

--- a/src/service/AbsencesService.hx
+++ b/src/service/AbsencesService.hx
@@ -1,4 +1,5 @@
 package service;
+import controller.Distribution;
 import tink.core.Error;
 
 /**
@@ -60,31 +61,10 @@ class AbsencesService {
 
 		if ( !catalog.hasAbsencesManagement() ) return 0;
 		return catalog.absentDistribsMaxNb;
-
-		/*if ( subscription == null || subscription.startDate == null || subscription.endDate == null ||
-			( subscription.startDate.getTime() <= catalog.absencesStartDate.getTime() && subscription.endDate.getTime() >= catalog.absencesEndDate.getTime() ) ) {
-			return catalog.absentDistribsMaxNb;
-		} else {
-
-			var absencesDistribsNbDuringSubscription = 0;
-			if ( subscription.startDate.getTime() > catalog.absencesStartDate.getTime() && subscription.endDate.getTime() < catalog.absencesEndDate.getTime() ) {
-				absencesDistribsNbDuringSubscription = db.Distribution.manager.count( $catalog == catalog && $date >= subscription.startDate && $end <= subscription.endDate );
-			} else if ( subscription.startDate.getTime() > catalog.absencesStartDate.getTime() ) {
-				absencesDistribsNbDuringSubscription = db.Distribution.manager.count( $catalog == catalog && $date >= subscription.startDate && $end <= catalog.absencesEndDate );
-			} else {
-				absencesDistribsNbDuringSubscription = db.Distribution.manager.count( $catalog == catalog && $date >= catalog.absencesStartDate && $end <= subscription.endDate );
-			}
-
-			if ( absencesDistribsNbDuringSubscription <= catalog.absentDistribsMaxNb ) {
-				return absencesDistribsNbDuringSubscription;
-			} else {
-				return catalog.absentDistribsMaxNb;
-			}
-		}*/
 	}
 
 	/**
-		get automatically absence distributions from an asbence number ( last distributions of the subscription )
+		get automatically absence distributions from an absence number ( last distributions of the subscription )
 	**/
 	public static function getAutomaticAbsentDistribs(catalog:db.Catalog, absencesNb:Int):Array<db.Distribution>{		
 		if( !catalog.hasAbsencesManagement() ) return [];
@@ -106,43 +86,6 @@ class AbsencesService {
 	}
 
 	/**
-		Update Absences Number on an existing subscription
-	**/
-	/*public static function setAbsencesNb( subscription:db.Subscription, absencesNb:Int, adminMode:Bool ) {
-
-		if( subscription == null ) throw new Error( 'La souscription n\'existe pas' );
-		if( !subscription.catalog.hasAbsencesManagement() ) return;
-		if(absencesNb==null) return;
-		
-		//a user can only choose absenceNb on subscription creation
-		//an admin can change it at anytime
-		if ( subscription.id == null || adminMode) {
-			
-			if(absencesNb == subscription.getAbsencesNb()){
-				return;
-			}
-			
-			if ( absencesNb > subscription.catalog.absentDistribsMaxNb ) {
-				throw new Error( 'Nombre de jours d\'absence invalide, vous avez droit à ${subscription.catalog.absentDistribsMaxNb} jours d\'absence maximum.' );
-			}
-
-			var distribs = subscription.getPossibleAbsentDistribs();
-			if ( absencesNb > distribs.length ) {
-				throw new Error( 'Nombre de jours d\'absence invalide, il n\'y a que ${distribs.length} distributions pendant le période d\'absence de cette souscription.' );
-			}
-
-
-			//sort from later to sooner distrib
-			distribs.sort( (a,b)-> Math.round(b.date.getTime()/1000) - Math.round(a.date.getTime()/1000) );
-
-			subscription.setAbsences( distribs.slice(0,absencesNb).map(d -> d.id) );
-
-		} else {
-			throw new Error('Il n\'est pas possible de modifier le nombre de jours d\'absence sur une souscription déjà créée.' );			
-		}
-	}*/
-
-	/**
 		can change absences number ?
 	**/
 	public static function canAbsencesNbBeEdited( catalog:db.Catalog, subscription:db.Subscription ):Bool {
@@ -160,16 +103,6 @@ class AbsencesService {
 		}else{
 			return true;
 		}
-		// var lastDistribBeforeAbsences = getLastDistribBeforeAbsences( catalog );
-		// if( lastDistribBeforeAbsences == null ) return false;
-
-		// var deadline = lastDistribBeforeAbsences.date.getTime();
-		// var beforeDeadline = Date.now().getTime() < deadline;
-		// var subscriptionInAbsencesPeriod = subscription == null || ( subscription.startDate.getTime() < deadline && subscription.endDate.getTime() > catalog.absencesStartDate.getTime() );
-		// var forbidden = catalog.type == db.Catalog.TYPE_CONSTORDERS && subscription != null && subscription.paid();
-
-		// return !forbidden && beforeDeadline && subscriptionInAbsencesPeriod;
-		
 	}
 
 	/**
@@ -199,9 +132,9 @@ class AbsencesService {
 				
 				// check the dates of previous absence that becomes presence
 				var newDistribPresence:Array<Int> = new Array<Int>();
-			for (i in 0...oldAbsentDistribIds.length) {
-				var distributionId = oldAbsentDistribIds[i];
-				if (!newAbsentDistribIds.has(distributionId)) {
+				for (i in 0...oldAbsentDistribIds.length) {
+					var distributionId = oldAbsentDistribIds[i];
+					if (!newAbsentDistribIds.has(distributionId)) {
 						newDistribPresence.push(distributionId);
 					}
 				}
@@ -228,11 +161,10 @@ class AbsencesService {
 							} catch (e : Error) {
 								throw new Error(Forbidden, 'Impossible de créer la commande par défaut sur la date où vous n\'êtes plus absent (${DateTools.format(distribution.date,"%d/%m/%Y")}): ${e.message}');
 							}
- 						}
+						}
 					}
 				}
 			}
-
 		}
 
 	}

--- a/src/service/OrderService.hx
+++ b/src/service/OrderService.hx
@@ -150,7 +150,7 @@ class OrderService
 
 					// si stock à 0 annuler commande
 					if (availableStock == 0 && orderedQuantity > 0) {
-						throw new Error(Forbidden, '${DateTools.format(distrib.date,"%d/%m/%Y")}: le stock de ${product.name} est épuisé pour cette date.' + product.qt);	
+						throw new Error(Forbidden, '${DateTools.format(distrib.date,"%d/%m/%Y")}: le stock de ${product.name} est épuisé pour cette date.');	
 					} else if (availableStock != null && orderedQuantity > availableStock) {
 						throw new Error(Forbidden, '${DateTools.format(distrib.date,"%d/%m/%Y")}: le stock de ${product.name} n\'est pas suffisant, vous ne pouvez commander plus de ${availableStock} ${product.name}');	
 					}

--- a/src/service/SubscriptionService.hx
+++ b/src/service/SubscriptionService.hx
@@ -944,25 +944,7 @@ class SubscriptionService
 		createOrUpdateTotalOperation( subscription );
 
 		return orders;	
-	}	
-
-	/*public static function getLastDistribBeforeAbsences( catalog:db.Catalog ) : db.Distribution {
-
-		if ( !catalog.hasAbsencesManagement() ) return null;
-		
-		var catalogDistribs = catalog.getDistribs( false ).array();
-		var lastDistribBeforeAbsences : db.Distribution = catalogDistribs[0];
-		for ( distrib in catalogDistribs ) {
-
-			if ( distrib.date.getTime() < catalog.absencesStartDate.getTime() ) {
-				lastDistribBeforeAbsences = distrib;
-			} else {
-				break;
-			}
-		}
-
-		return lastDistribBeforeAbsences;
-	}*/
+	}
 
 	/**
 		Update default orders (store it in the subscription entity) and create the recurrent UserOrders


### PR DESCRIPTION
Dans le cadre d'un changement d'absence sur un contrat variable pour lequel une commande par défaut est configurée :
- supprime la commande précédente sur la date qui devient une absence;
- créer immédiatement la commande sur la date qui n'est plus une absence, d'après la commande par défaut.
En cas d'erreur lors de la création de commande (ex: erreur de stock), le changement d'absence est annulé avec message d'erreur.
![image](https://github.com/CAMAP-APP/camap-hx/assets/722132/a5b2cefe-1767-4c23-9e0b-688e2d9d91a4)

https://app.clickup.com/t/86bz8btqg