### PR TITLE
#278

### DIFF
--- a/lang/master/tpl/contractadmin/distributions.mtt
+++ b/lang/master/tpl/contractadmin/distributions.mtt
@@ -7,9 +7,10 @@
 	</p>
 
 	<p>
-		<a href="/contractAdmin/distributions/::c.id::?participateToAllDistributions=1&_from=::timeframe.from.toString()::&_to=::timeframe.to.toString()::" class="btn btn-default">
-			<i class="icon icon-check"></i> Participer à toutes les distributions du ::dDate(participationTimeframe.from):: au ::dDate(participationTimeframe.to)::
-		</a>		
+		<a href="/contractAdmin/distributions/::c.id::?participateToAllDistributions=1&$$timeframeQueryParams(::timeframe.from::,::timeframe.to::)" class="btn btn-default">
+			<i class="icon icon-check"></i> Participer à toutes les distributions
+		</a>
+		&nbsp&nbspdu ::dDate(participationTimeframe.from):: au ::dDate(participationTimeframe.to)::
 	</p>
 
 	<table class="table">
@@ -36,11 +37,9 @@
 				</td>
 				<td style="width: 0.1%; white-space: nowrap; text-align: right">
 					::if(d==null)::
-						<td>
-							<a href="/contractAdmin/participate/::md.id::/::c.id::?_from=::timeframe.from.toString()::&_to=::timeframe.to.toString()::" class="btn btn-default btn-sm">
-								<i class="icon icon-plus"></i> ::_("Participate")::
-							</a>
-						</td>
+						<a href="/contractAdmin/participate/::md.id::/::c.id::?$$timeframeQueryParams(::timeframe.from::,::timeframe.to::)" class="btn btn-default btn-sm">
+							<i class="icon icon-plus"></i> ::_("Participate")::
+						</a>
 					::else::
 						<span style="display:none;">::d.populate()::</span>
 						<!-- <div class="btn-group" style="white-space: nowrap"> -->
@@ -74,7 +73,7 @@
 								<i class="icon icon-print"></i>&nbsp;::_("Distribution list")::
 							</a>-->
 
-							<a href="/distribution/delete/::d.id::?_from=::timeframe.from.toString()::&_to=::timeframe.to.toString()::" class="btn btn-default btn-sm">
+							<a href="/distribution/delete/::d.id::?$$timeframeQueryParams(::timeframe.from::,::timeframe.to::)" class="btn btn-default btn-sm">
 								<i class="icon icon-delete"></i>&nbsp;Ne plus participer
 							</a>
 

--- a/lang/master/tpl/macros.mtt
+++ b/lang/master/tpl/macros.mtt
@@ -410,7 +410,8 @@
 				<i class="icon icon-chevron-right"></i>
 			</a>
 		</div>
-	</macro>	
+	</macro>
+	<macro name="timeframeQueryParams(from,to)">_from=::from.toString().substr(0,10)::&_to=::to.toString().substr(0,10)::</macro>
 	
 	<macro name="footer()">
 		::if(theme!=null && theme.footer!=null)::

--- a/src/controller/ContractAdmin.hx
+++ b/src/controller/ContractAdmin.hx
@@ -941,13 +941,15 @@ class ContractAdmin extends Controller
 	}
 
 	function doParticipate(md:db.MultiDistrib,contract:db.Catalog){
+		var timeframe = '_from=${app.params.get("_from")}&_to=${app.params.get("_to")}';
+
 		try{
 			service.DistributionService.participate(md,contract);
 		}catch(e:tink.core.Error){
-			throw Error("/contractAdmin/distributions/"+contract.id,e.message);
+			throw Error('/contractAdmin/distributions/${contract.id}?${timeframe}',e.message);
 		}
 		
-		throw Ok('/contractAdmin/distributions/${contract.id}?_from=${app.params.get("_from")}&_to=${app.params.get("_to")}',t._("Distribution date added"));
+		throw Ok('/contractAdmin/distributions/${contract.id}?${timeframe}',t._("Distribution date added"));
 	}
 	
 	@tpl("contractadmin/view.mtt")


### PR DESCRIPTION
- fix: Sur la page "Catalogues / Distributions" lorsqu'on a défilé pour atteindre une plage de dates ultérieures et que l'on clique sur participer, on souhaiterait rester sur l'affichage des distribution de la même plage calendaire (la plage est passée par URL).