### PR TITLE
mantis-181 : ajouter "Vous pouvez répondre à" en pied de mail

### DIFF
--- a/lang/master/tpl/mail/layout-group.mtt
+++ b/lang/master/tpl/mail/layout-group.mtt
@@ -165,6 +165,9 @@
 				href="https://wiki.amap44.org/fr/app/mon-compte-camap#quitter-un-groupe" rel="notrack">quitter ce
 				groupe</a></p>
 		::end::
+	::if (replyTo!=null)::
+	<p>Vous pouvez répondre à : <a href="::'mailto:'+replyTo::">::replyTo::</a></p>
+	::end::
 	</div>
 </body>
 

--- a/src/controller/Cron.hx
+++ b/src/controller/Cron.hx
@@ -585,7 +585,8 @@ class Cron extends Controller {
 							group: group,
 							multiDistrib: u.distrib,
 							user: u.user,
-							hHour: Formatting.hHour
+							hHour: Formatting.hHour,
+							replyTo: group.contact != null ? group.contact.email : null
 						}));
 						App.sendMail(m, group);
 
@@ -676,7 +677,8 @@ class Cron extends Controller {
 								group: group,
 								multiDistrib: md,
 								user: user,
-								hHour: Formatting.hHour
+								hHour: Formatting.hHour,
+								replyTo: group.contact != null ? group.contact.email : null
 							}));
 							App.sendMail(m, group);
 
@@ -760,7 +762,8 @@ class Cron extends Controller {
 					dDate: Formatting.dDate,
 					hHour: Formatting.hHour,
 					group: amap,
-					newSubscriptions: distribOrders.newSubs
+					newSubscriptions: distribOrders.newSubs,
+					replyTo: amap.contact != null ? amap.contact.email : null
 				});
 
 				m.setHtmlBody(html);

--- a/src/service/OrderService.hx
+++ b/src/service/OrderService.hx
@@ -539,7 +539,7 @@ class OrderService
 			m.setSubject(title);
 			var orders = prepare(d.catalog.getUserOrders(user,d));
 
-			var html = App.current.processTemplate("mail/orderSummaryForMember.mtt", { 
+			var html = App.current.processTemplate("mail/orderSummaryForMember.mtt", {
 				contract:d.catalog,
 				distribution:d,
 				orders:orders,
@@ -547,7 +547,8 @@ class OrderService
 				currency:App.current.view.currency,
 				dDate:Formatting.dDate,
 				hHour:Formatting.hHour,
-				group:d.catalog.group
+				group:d.catalog.group,
+				replyTo:d.catalog.contact.email
 			} );
 			
 			m.setHtmlBody(html);


### PR DESCRIPTION
Ajoute dans le footer du layout-group la mention de l'adresse Reply-To lorsqu'elle est définie. Transmet le champ replyTo dans le contexte des templates concernés : notifications de commande (mono et multi-distrib), récapitulatif commande membre, et rapport commandes par produit vendeur.