### PR TITLE
[fix] Interdire la suppression de participation si une distribution a déjà eu lieu (TYPE_CONSTORDERS)

### DIFF
--- a/src/service/DistributionService.hx
+++ b/src/service/DistributionService.hx
@@ -589,6 +589,9 @@ class DistributionService
 		}
 
 		if ( !canDelete(d) ) {
+			if (d.catalog.type == db.Catalog.TYPE_CONSTORDERS) {
+				throw new Error("Vous ne pouvez pas supprimer cette participation car au moins une distribution de ce contrat a déjà eu lieu.");
+			}
 			throw new Error(t._("Deletion not possible: orders are recorded for ::vendorName:: on ::date::.",{vendorName:d.catalog.vendor.name,date:Formatting.hDate(d.date)}));
 		}
 

--- a/src/service/DistributionService.hx
+++ b/src/service/DistributionService.hx
@@ -559,7 +559,9 @@ class DistributionService
 	 */
 	public static function canDelete(d:db.Distribution):Bool{
 
-		if (d.catalog.type == db.Catalog.TYPE_CONSTORDERS) return true;
+		if (d.catalog.type == db.Catalog.TYPE_CONSTORDERS) {
+			return db.Distribution.manager.count( $catalog == d.catalog && $date < Date.now() ) == 0;
+		}
 		
 		var quantity = 0.0;
 		for ( order in d.getOrders() ){


### PR DESCRIPTION
# [fix] Interdire la suppression de participation si une distribution a déjà eu lieu (TYPE_CONSTORDERS)

## Description :

### Contexte
Pour les catalogues de type CONST_ORDERS (contrats/souscriptions), la méthode canDelete dans DistributionService retournait systématiquement true, autorisant la suppression de n'importe quelle distribution même lorsque le contrat était déjà en cours d'exécution.

### Problème
La suppression d'une participation à une distribution dans un catalogue TYPE_CONSTORDERS devrait être impossible dès lors qu'au moins une distribution de ce catalogue a déjà eu lieu. Le comportement précédent ne respectait pas cette règle métier.

### Solution

1. Correction de canDelete — remplacement du return true inconditionnel par une vérification en base : la suppression n'est autorisée que si aucune distribution du même catalogue n'a de date antérieure à aujourd'hui.

```haxe
if (d.catalog.type == db.Catalog.TYPE_CONSTORDERS) {
    return db.Distribution.manager.count( $catalog == d.catalog && $date < Date.now() ) == 0;
}
```

2. Message d'erreur explicite — ajout d'un message spécifique à TYPE_CONSTORDERS dans cancelParticipation pour éviter d'afficher le message générique « orders are recorded ».

```haxe
if (d.catalog.type == db.Catalog.TYPE_CONSTORDERS) {
    throw new Error("Vous ne pouvez pas supprimer cette participation car au moins une distribution de ce contrat a déjà eu lieu.");
}
```

###  Comment tester

Créer un catalogue de type CONST_ORDERS avec plusieurs distributions planifiées
Laisser passer la date d'au moins une distribution
Tenter de supprimer la participation d'un producteur à n'importe quelle distribution du catalogue → doit être bloqué
Vérifier qu'avant toute distribution passée, la suppression reste possible
Vérifier que les catalogues de type VAR_ORDERS ne sont pas impactés (comportement inchangé)