### PR TITLE
[fix] Correction d'exceptions non trappées (emails invalides, souscription vide)

### DIFF
--- a/src/controller/Cron.hx
+++ b/src/controller/Cron.hx
@@ -119,9 +119,17 @@ class Cron extends Controller {
 					mail.setSender(App.current.getTheme().email.senderEmail, App.current.getTheme().name);
 					var volunteersList = "<ul>";
 					for (volunteer in volunteers) {
-						mail.addRecipient(volunteer.user.email, volunteer.user.getName());
+						try {
+							mail.addRecipient(volunteer.user.email, volunteer.user.getName());
+						} catch (e:Dynamic) {
+							task.log('Invalid email for volunteer ${volunteer.user.getName()}: ${volunteer.user.email}');
+						}
 						if (volunteer.user.email2 != null) {
-							mail.addRecipient(volunteer.user.email2);
+							try {
+								mail.addRecipient(volunteer.user.email2);
+							} catch (e:Dynamic) {
+								task.log('Invalid email2 for volunteer ${volunteer.user.getName()}: ${volunteer.user.email2}');
+							}
 						}
 						volunteersList += "<li>" + volunteer.volunteerRole.name + " : " + volunteer.user.getCoupleName() + "</li>";
 					}
@@ -168,9 +176,17 @@ class Cron extends Controller {
 				var mail = new Mail();
 				mail.setSender(App.current.getTheme().email.senderEmail, App.current.getTheme().name);
 				for (member in multidistrib.group.getMembers()) {
-					mail.addRecipient(member.email, member.getName());
+					try {
+						mail.addRecipient(member.email, member.getName());
+					} catch (e:Dynamic) {
+						task.log('Invalid email for member ${member.getName()}: ${member.email}');
+					}
 					if (member.email2 != null) {
-						mail.addRecipient(member.email2);
+						try {
+							mail.addRecipient(member.email2);
+						} catch (e:Dynamic) {
+							task.log('Invalid email2 for member ${member.getName()}: ${member.email2}');
+						}
 					}
 				}
 

--- a/src/service/SubscriptionService.hx
+++ b/src/service/SubscriptionService.hx
@@ -555,7 +555,7 @@ class SubscriptionService {
 		// get orders in correct format
 		var allOrders = getSubscriptionAllOrders(subscription);
 		if (allOrders.length == 0)
-			throw "Aucune commande dans cette souscription";
+			throw new Error("Aucune commande dans cette souscription");
 		var ordersByDistrib = ordersToOrdersByDistrib(allOrders);
 
 		checkVarOrders(ordersByDistrib, subscription);
@@ -575,7 +575,7 @@ class SubscriptionService {
 		for (k in ordersByDistrib.keys())
 			keys.push(k);
 		if (keys.length == 0)
-			throw "Aucune distribution ouverte à la commande pour cette souscription";
+			throw new Error("Aucune distribution ouverte à la commande pour cette souscription");
 		var catalog = keys.find(d -> d != null).catalog;
 
 		// Minimum by distribution
@@ -647,7 +647,7 @@ class SubscriptionService {
 		if (startDate == null)
 			startDate = getNewSubscriptionStartDate(catalog);
 		if (startDate == null)
-			throw "Aucune distribution non fermée dans le futur";
+			throw new Error("Aucune distribution non fermée dans le futur");
 		if (endDate == null)
 			endDate = catalog.endDate;
 

--- a/src/service/VolunteerService.hx
+++ b/src/service/VolunteerService.hx
@@ -148,9 +148,17 @@ class VolunteerService
 					}
 					var adminUsers = service.GroupService.getGroupMembersWithRights( multidistrib.group, rights );
 					for ( admin in adminUsers ) {
-						mail.addRecipient( admin.email, admin.getName() );
+						try {
+							mail.addRecipient( admin.email, admin.getName() );
+						} catch (e:Dynamic) {
+							trace('Invalid email for admin ${admin.getName()}: ${admin.email}');
+						}
 						if ( admin.email2 != null ) {
-							mail.addRecipient( admin.email2 );
+							try {
+								mail.addRecipient( admin.email2 );
+							} catch (e:Dynamic) {
+								trace('Invalid email2 for admin ${admin.getName()}: ${admin.email2}');
+							}
 						}
 					}
 				}else{
@@ -158,9 +166,17 @@ class VolunteerService
 					var members = Lambda.array( multidistrib.group.getMembers() );
 					//Recipients are all members
 					for ( member in members ) {
-						mail.addRecipient( member.email, member.getName() );
+						try {
+							mail.addRecipient( member.email, member.getName() );
+						} catch (e:Dynamic) {
+							trace('Invalid email for member ${member.getName()}: ${member.email}');
+						}
 						if ( member.email2 != null ) {
-							mail.addRecipient( member.email2 );
+							try {
+								mail.addRecipient( member.email2 );
+							} catch (e:Dynamic) {
+								trace('Invalid email2 for member ${member.getName()}: ${member.email2}');
+							}
 						}
 					}
 				}


### PR DESCRIPTION
[fix] Correction d'exceptions non trappées (emails invalides, souscription vide)

## Contexte

Deux erreurs non trappées remontaient en production :

1. Dans `SubscriptionAdmin`, la création d'une souscription sans commande levait un `throw "string"` brut dans `SubscriptionService.areVarOrdersValid()` qui n'était pas attrapé par le `catch (error:Error)` du contrôleur (qui attend un `tink.core.Error`).

2. Dans le cron `/cron/hour`, `sugoi/mail/Mail.addRecipient()` lève une exception pour les adresses email invalides (ex. `yahoo.f`), crashant l'ensemble de la tâche cron.

## Solution

- `SubscriptionService` : remplace les trois `throw "string"` par `throw new Error(...)` pour qu'ils soient correctement rattrapés par les contrôleurs.
- `Cron` et `VolunteerService` : entoure chaque appel `addRecipient()` d'un `try/catch (e:Dynamic)` pour ignorer les adresses invalides sans interrompre l'envoi aux autres destinataires. L'adresse problématique est loggée.

## Comment tester

- Tenter de créer une souscription sans sélectionner de commande → message d'erreur affiché proprement au lieu d'une page d'erreur.
- Vérifier que le cron `hour` s'exécute sans erreur même si un membre a une adresse email mal formée.