### PR TITLE
[feature] Bannière instance de test : hôtes "local" et message mis à jour

### DIFF
--- a/lang/master/tpl/base.mtt
+++ b/lang/master/tpl/base.mtt
@@ -61,10 +61,10 @@
     <div style="position: fixed;background: #666;padding: 8px;left: 0;bottom:0;color:#FF0;">DEBUG</div>
     ::end::
 
-    ::if ( HOST.indexOf("dev",null)!=-1 )::
+    ::if ( HOST.indexOf("dev",null)!=-1 || HOST.indexOf("local",null)!=-1 )::
     <div style="position: fixed;background: #600;padding: 8px;left:0;bottom:0;color: #FA0;width: 100%;z-index: 99;text-align: center;">
         <i class="icon icon-alert"></i>
-        <b>Ce site est une instance de test.</b> Ne l'utilisez pas pour prendre de vraies commandes.
+        <b>Ce site est une instance de test.</b> Toutes les données peuvent être effacées sans préavis.
     </div>
     ::end::
 


### PR DESCRIPTION
## Contexte

La bannière d'avertissement bas de page n'apparaissait que pour les hôtes
contenant "dev". Elle n'était donc pas affichée sur les environnements locaux
(ex. `camap.local` sous minikube).

## Solution

- Ajout de `HOST.indexOf("local",null)!=-1` à la condition d'affichage
- Message mis à jour : "Toutes les données peuvent être effacées sans préavis."

## Comment tester

- Vérifier la présence de la bannière sur un hôte contenant "dev" (ex. `camapdev.amap44.org`)
- Vérifier la présence de la bannière sur un hôte contenant "local" (ex. `camap.local`)
- Vérifier l'absence de la bannière sur un hôte de production

## Checklist

- [x] La branche est créée depuis `staging` (et à jour avec `staging`)
- [x] Le code compile sans erreur
- [x] Les fonctionnalités existantes ne sont pas régressées