### PR TITLE
[mantis-327] Notifications : ajouter l'année dans l'objet des emails

### DIFF
--- a/src/App.hx
+++ b/src/App.hx
@@ -18,7 +18,7 @@ class App extends sugoi.BaseApp {
 	 * Version management
 	 * @doc https://github.com/fponticelli/thx.semver
 	 */
-	public static var VERSION = ([3, 0, 7] : Version) /*.withPre(GitMacros.getGitShortSHA(), GitMacros.getGitCommitDate())*/;
+	public static var VERSION = ([3, 0, 8] : Version) /*.withPre(GitMacros.getGitShortSHA(), GitMacros.getGitCommitDate())*/;
 
 	public function new() {
 		super();

--- a/src/View.hx
+++ b/src/View.hx
@@ -182,8 +182,8 @@ class View extends sugoi.BaseView {
 	/**
 	 * human readable date + time
 	 */
-	public function hDate(date:Date):String {
-		return Formatting.hDate(date);
+	public function hDate(date:Date, ?year:Bool = false):String {
+		return Formatting.hDate(date, year);
 	}
 
 	/**

--- a/src/controller/Cron.hx
+++ b/src/controller/Cron.hx
@@ -135,7 +135,7 @@ class Cron extends Controller {
 					}
 					volunteersList += "</ul>";
 
-					mail.setSubject(t._("Instructions for the volunteers of the ::date:: distribution", {date: view.hDate(multidistrib.distribStartDate)}));
+					mail.setSubject(t._("Instructions for the volunteers of the ::date:: distribution", {date: view.hDate(multidistrib.distribStartDate, true)}));
 
 					// Let's replace all the tokens
 					var ddate = t._("::date:: from ::startHour:: to ::endHour::", {
@@ -194,7 +194,7 @@ class Cron extends Controller {
 				var vacantVolunteerRolesList = "<ul>"
 					+ Lambda.map(multidistrib.getVacantVolunteerRoles(), function(r) return "<li>" + r.name + "</li>").join("\n")
 					+ "</ul>";
-				mail.setSubject("Besoin de volontaires pour la distribution du " + view.hDate(multidistrib.distribStartDate));
+				mail.setSubject("Besoin de volontaires pour la distribution du " + view.hDate(multidistrib.distribStartDate, true));
 
 				// Let's replace all the tokens
 				var ddate = view.dDate(multidistrib.distribStartDate) + " de " + view.hHour(multidistrib.distribStartDate) + " à "
@@ -595,7 +595,7 @@ class Cron extends Controller {
 						m.addRecipient(u.user.email, u.user.getName());
 						if (u.user.email2 != null)
 							m.addRecipient(u.user.email2);
-						m.setSubject(t._("Distribution on ::date::", {date: app.view.hDate(u.distrib.distribStartDate)}));
+						m.setSubject(t._("Distribution on ::date::", {date: app.view.hDate(u.distrib.distribStartDate, true)}));
 						m.setHtmlBody(app.processTemplate("mail/orderNotif.mtt", {
 							text: text,
 							group: group,
@@ -686,7 +686,7 @@ class Cron extends Controller {
 							m.addRecipient(user.email, user.getName());
 							if (user.email2 != null)
 								m.addRecipient(user.email2);
-							m.setSubject(t._("Distribution on ::date::", {date: app.view.hDate(md.distribStartDate)}));
+							m.setSubject(t._("Distribution on ::date::", {date: app.view.hDate(md.distribStartDate, true)}));
 
 							m.setHtmlBody(app.processTemplate("mail/orderNotif.mtt", {
 								text: text,

--- a/src/service/VolunteerService.hx
+++ b/src/service/VolunteerService.hx
@@ -180,7 +180,7 @@ class VolunteerService
 						}
 					}
 				}
-				var date = App.current.view.hDate(multidistrib.distribStartDate);
+				var date = App.current.view.hDate(multidistrib.distribStartDate, true);
 				var subject = t._( "A role has been left for ::date:: distribution",{date:date});
 				mail.setSubject( subject );
 				var html = App.current.processTemplate("mail/volunteerUnsuscribed.mtt", { fullname : user.getName(), role : role.name, reason : reason, group: multidistrib.group  } );


### PR DESCRIPTION
## Contexte

Les objets des emails de notification affichaient les dates sans l'année
(ex : "Distribution du Mardi 24 Juin"), ce qui prête à confusion quand des
distributions sont planifiées sur plusieurs saisons.

## Solution

`Formatting.hDate()` supportait déjà un paramètre optionnel `year=false`.
Il suffisait de le propager et de l'activer pour les sujets concernés.

Fichiers modifiés :
- `src/View.hx` : ajout de `?year:Bool = false` dans `hDate()` avec transmission à `Formatting.hDate()`
- `src/controller/Cron.hx` : passage de `year=true` sur les 4 sujets (distribution ×2, besoin de volontaires, instructions bénévoles)
- `src/service/VolunteerService.hx` : passage de `year=true` sur le sujet abandon de rôle

Aucun effet de bord : le paramètre étant optionnel avec `false` par défaut, tous les autres appels (templates `.mtt`, messages d'erreur, corps de mails) sont inchangés.

## Comment tester

Déclencher chacun des 4 types de notification et vérifier que l'objet du mail contient bien l'année, ex : "Distribution du Mardi 24 Juin 2026".

---
🤖 Co-rédigé avec [Claude](https://claude.ai/code)