### PR TITLE
[fix] View.hDate — Invalid call dans les templates Distributions et ContractAdmin

### DIFF
--- a/src/View.hx
+++ b/src/View.hx
@@ -181,9 +181,10 @@ class View extends sugoi.BaseView {
 
 	/**
 	 * human readable date + time
+	 * Note: no optional param — Templo cannot call functions with optional parameters
 	 */
-	public function hDate(date:Date, ?year:Bool = false):String {
-		return Formatting.hDate(date, year);
+	public function hDate(date:Date):String {
+		return Formatting.hDate(date);
 	}
 
 	/**

--- a/src/controller/Cron.hx
+++ b/src/controller/Cron.hx
@@ -135,7 +135,7 @@ class Cron extends Controller {
 					}
 					volunteersList += "</ul>";
 
-					mail.setSubject(t._("Instructions for the volunteers of the ::date:: distribution", {date: view.hDate(multidistrib.distribStartDate, true)}));
+					mail.setSubject(t._("Instructions for the volunteers of the ::date:: distribution", {date: Formatting.hDate(multidistrib.distribStartDate, true)}));
 
 					// Let's replace all the tokens
 					var ddate = t._("::date:: from ::startHour:: to ::endHour::", {
@@ -194,7 +194,7 @@ class Cron extends Controller {
 				var vacantVolunteerRolesList = "<ul>"
 					+ Lambda.map(multidistrib.getVacantVolunteerRoles(), function(r) return "<li>" + r.name + "</li>").join("\n")
 					+ "</ul>";
-				mail.setSubject("Besoin de volontaires pour la distribution du " + view.hDate(multidistrib.distribStartDate, true));
+				mail.setSubject("Besoin de volontaires pour la distribution du " + Formatting.hDate(multidistrib.distribStartDate, true));
 
 				// Let's replace all the tokens
 				var ddate = view.dDate(multidistrib.distribStartDate) + " de " + view.hHour(multidistrib.distribStartDate) + " à "
@@ -595,7 +595,7 @@ class Cron extends Controller {
 						m.addRecipient(u.user.email, u.user.getName());
 						if (u.user.email2 != null)
 							m.addRecipient(u.user.email2);
-						m.setSubject(t._("Distribution on ::date::", {date: app.view.hDate(u.distrib.distribStartDate, true)}));
+						m.setSubject(t._("Distribution on ::date::", {date: Formatting.hDate(u.distrib.distribStartDate, true)}));
 						m.setHtmlBody(app.processTemplate("mail/orderNotif.mtt", {
 							text: text,
 							group: group,
@@ -686,7 +686,7 @@ class Cron extends Controller {
 							m.addRecipient(user.email, user.getName());
 							if (user.email2 != null)
 								m.addRecipient(user.email2);
-							m.setSubject(t._("Distribution on ::date::", {date: app.view.hDate(md.distribStartDate, true)}));
+							m.setSubject(t._("Distribution on ::date::", {date: Formatting.hDate(md.distribStartDate, true)}));
 
 							m.setHtmlBody(app.processTemplate("mail/orderNotif.mtt", {
 								text: text,

--- a/src/service/VolunteerService.hx
+++ b/src/service/VolunteerService.hx
@@ -180,7 +180,7 @@ class VolunteerService
 						}
 					}
 				}
-				var date = App.current.view.hDate(multidistrib.distribStartDate, true);
+				var date = Formatting.hDate(multidistrib.distribStartDate, true);
 				var subject = t._( "A role has been left for ::date:: distribution",{date:date});
 				mail.setSubject( subject );
 				var html = App.current.processTemplate("mail/volunteerUnsuscribed.mtt", { fullname : user.getName(), role : role.name, reason : reason, group: multidistrib.group  } );


### PR DESCRIPTION
[fix] View.hDate — Invalid call dans les templates Distributions et ContractAdmin

## Contexte

La v3.0.8 (merge staging→master) introduit une régression sur deux pages :
- Menu **Distributions** (`/distribution`)
- Menu **ContractAdmin / Commandes** (`/contractAdmin/view/…`)

Les deux affichent `Invalid call` au rendu Templo de `::hDate(d.date)::`.

## Cause

Le commit `bdbbd8de` a ajouté `?year:Bool = false` à `View.hDate`. Or,
comme le précise `BaseView.hx` :
> "templo doesnt manage optional params in functions"

Neko compile la fonction à **2 arguments** ; Templo l'appelle avec **1** → crash.

## Solution

- `View.hDate` revient à 1 argument, sans paramètre optionnel
- Les 5 appels `view.hDate(date, true)` dans `Cron.hx` et `VolunteerService.hx`
  utilisent directement `Formatting.hDate(date, true)`

## Test

1. Admin → **Distributions** → plus d'`Invalid call`
2. ContractAdmin → **Commandes** → plus d'`Invalid call`
3. Vérifier qu'un email bénévole contient la date avec l'année

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>