### PR TITLE
[fix] Correction de l'erreur "Invalid operation (*)" sur /contractAdmin/orders

### DIFF
--- a/lang/master/tpl/contractadmin/orders.mtt
+++ b/lang/master/tpl/contractadmin/orders.mtt
@@ -119,8 +119,10 @@
 								<span style="color:#AAA">::_("Canceled")::</span>
 							::else::
 								::if(o.product.multiWeight && o.product.variablePrice)::
+								::set effectiveQt = o.productQt::
+								::if effectiveQt == null::::set effectiveQt = 1::::end::
 								<div class="orderQtInput hidden">
-									<input type="text" id="::o.id::_qt" value="::formatNum(o.quantity * o.productQt)::"
+									<input type="text" id="::o.id::_qt" value="::formatNum(o.quantity * effectiveQt)::"
 										title="::unit(o.productUnit,o.quantity>0):: ::o.productName:: ::basket._user.getName()::"
 										style="width:70%;"
 										onchange="this.style.color = 'initial'"
@@ -128,7 +130,7 @@
 									/>&nbsp;::unit(o.productUnit,o.quantity>0)::
 								</div>
 									<script>
-										let  qt_::o.id::_lastVal = '::formatNum(o.quantity * o.productQt)::';
+										let  qt_::o.id::_lastVal = '::formatNum(o.quantity * effectiveQt)::';
 										document.getElementById("::o.id::_qt").addEventListener("keydown", blurOnEnter);
 									</script>
 								::end::


### PR DESCRIPTION
## Contexte

Une erreur serveur "Invalid operation (*)" se produisait sur la page
`/contractAdmin/orders/<id>` pour certains catalogues, rendant la page
inaccessible.

Trace :
  Called from contractadmin/orders.mtt line 123
  at URL /contractAdmin/orders/82897

## Cause

Le template tente d'afficher `o.quantity * o.productQt` dans l'input
de saisie du poids (bloc `multiWeight && variablePrice`). Or `product.qt`
est `SNull<SFloat>` — un produit peut avoir `multiWeight=true` sans `qt`
renseigné. Dans ce cas `o.productQt` est null et Neko lève
"Invalid operation (*)" à la multiplication.

## Solution

Introduction d'une variable locale `effectiveQt` dans le template :

::set effectiveQt = o.productQt::
::if effectiveQt == null::::set effectiveQt = 1::::end::



Cette valeur par défaut de 1 est cohérente avec `OrderService.updateUserOrderQuantity`
(ligne 872) qui applique le même fallback côté serveur.

Note : l'opérateur ternaire `? :` n'est pas supporté par le compilateur
Templo — d'où l'usage de deux instructions `::set::` / `::if::`.

## Comment tester

1. Identifier un produit avec multipesée + prix variable selon pesée et quantité nulle
2. Créer une commande sur ce produit pour une distribution
3. Ouvrir `/contractAdmin/orders/<catalog_id>?d=<distrib_id>`
4. Vérifier que la page s'affiche sans erreur et que l'input de pesée
   affiche la quantité (quantity × 1)

🤖 Co-rédigé avec [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>