### PR TITLE
[fix] Régression v3.0.8 — Invalid call dans Distributions / ContractAdmin

### DIFF
--- a/src/View.hx
+++ b/src/View.hx
@@ -183,8 +183,8 @@ class View extends sugoi.BaseView {
 	 * human readable date + time
 	 * Note: no optional param — Templo cannot call functions with optional parameters
 	 */
-	public function hDate(date:Date, ?year:Bool = false):String {
-		return Formatting.hDate(date, year);
+	public function hDate(date:Date):String {
+		return Formatting.hDate(date);
 	}
 
 	/**


### PR DESCRIPTION
## Contexte

La v3.0.8 a introduit une régression sur plusieurs pages (Distributions,
ContractAdmin/selectDistrib, ContractAdmin/distributions) avec l'erreur
`Invalid call` déclenchée par des appels à `::hDate(d.date)::` dans
les templates Templo.

## Cause

Le commit bdbbd8de a ajouté `?year:Bool = false` à `View.hDate`. Neko
compile cette fonction à 2 arguments ; Templo l'appelle avec 1 → crash.
(cf. `BaseView.hx` : *"templo doesnt manage optional params in functions"*)

## Commits inclus

- `049915f` — commentaire + migration Cron.hx / VolunteerService.hx
- `d8300af` — fix `Invalid operation (*)` dans orders.mtt
- ce commit — suppression effective de `?year` dans la signature de `View.hDate`

## Test

1. Admin → **Distributions** → aucune erreur
2. ContractAdmin → **Commandes** / **Distributions** → aucune erreur
3. Sujets des emails bénévoles : date avec année correcte

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>