### PR TITLE
[mantis-330/331] Refonte de la désinscription de permanence

### DIFF
--- a/lang/master/tpl/mail/volunteerUnsuscribed.mtt
+++ b/lang/master/tpl/mail/volunteerUnsuscribed.mtt
@@ -1,10 +1,7 @@
 :: use 'mail/layout-group.mtt'::
 
 <p>
-    ::raw __( "<b>::fullname::</b> has left the role <b>::role::</b> for the following reason:",{fullname:fullname,role:role})::
-</p>
-<p>
-    "<i>::reason::</i>"
+    ::raw __( "<b>::fullname::</b> has left the role <b>::role::</b>.",{fullname:fullname,role:role})::
 </p>
 <p>
     ::raw _("This role needs to be assigned to another person.")::

--- a/src/controller/Distribution.hx
+++ b/src/controller/Distribution.hx
@@ -971,44 +971,11 @@ class Distribution extends Controller {
 	}
 
 	/**
-		Remove current user from a volunteer role
-	**/ 
-	@tpl("form.mtt")
+		Legacy URL — désincription désormais gérée par le NeoModule volunteersCalendar
+	**/
 	function doUnsubscribeFromRole(distrib:db.MultiDistrib, role:db.VolunteerRole, ?args:{returnUrl:String, ?to:String}) {
-
-		if (args != null && args.returnUrl != null) {
-			var toArg = args.to != null ? "&to=" + args.to : "";
-			App.current.session.data.volunteersReturnUrl = args.returnUrl + toArg;
-		}
-
-		var form = new sugoi.form.Form("unsubscribe");
-
-		var returnUrl = App.current.session.data.volunteersReturnUrl != null ? App.current.session.data.volunteersReturnUrl : '/distribution/unsubscribeFromRole/'
-			+ distrib.id
-			+ '/'
-			+ role.id;
-
-		var volunteer = distrib.getVolunteerForRole(role);
-		if (volunteer == null) {
-			throw Error(returnUrl, t._("There is no volunteer to remove for this role!"));
-		} else if (volunteer.user.id != app.user.id) {
-			throw Error(returnUrl, t._("You can only remove yourself from a role."));
-		}
-
-		form.addElement(new TextArea("unsubscriptionreason", t._("Reason for leaving the role. Please note: a withdrawal notification including the content of this message will be sent by email to all members of the group"), null, true, null, "style='width:500px;height:350px;'"));
-
-		if (form.isValid()) {
-			try {
-				service.VolunteerService.removeUserFromRole(app.user, distrib, role, form.getValueOf("unsubscriptionreason"));
-			} catch (e:tink.core.Error) {
-				throw Error(returnUrl, e.message);
-			}
-
-			throw Ok(returnUrl, t._("You have been successfully removed from this role."));
-		}
-
-		view.title = t._("Enter the reason why you are leaving this role.");
-		view.form = form;
+		var returnUrl = args != null && args.returnUrl != null ? args.returnUrl : '/distribution/volunteersCalendar';
+		throw Redirect(returnUrl);
 	}
 
 	/**

--- a/src/controller/api/Distributions.hx
+++ b/src/controller/api/Distributions.hx
@@ -26,7 +26,7 @@ class Distributions extends Controller {
 		} else if (volunteer.user.id != app.user.id) {
 			throw new Error(403, t._("You can only remove yourself from a role."));
 		}
-		VolunteerService.removeUserFromRole(app.user, distrib, role, "");
+		VolunteerService.removeUserFromRole(app.user, distrib, role);
 		json({success: true});
 	}
 

--- a/src/controller/api/Distributions.hx
+++ b/src/controller/api/Distributions.hx
@@ -10,9 +10,24 @@ import service.VolunteerService;
 import service.DistributionService;
 
 class Distributions extends Controller {
-	
+
 	public function new() {
 		super();
+	}
+
+	/**
+		Remove current user from a volunteer role (REST endpoint, no reason required)
+	**/
+	function doUnsubscribeFromRole(distrib:db.MultiDistrib, role:db.VolunteerRole) {
+		checkIsLogged();
+		var volunteer = distrib.getVolunteerForRole(role);
+		if (volunteer == null) {
+			throw new Error(422, t._("There is no volunteer to remove for this role!"));
+		} else if (volunteer.user.id != app.user.id) {
+			throw new Error(403, t._("You can only remove yourself from a role."));
+		}
+		VolunteerService.removeUserFromRole(app.user, distrib, role, "");
+		json({success: true});
 	}
 
 	/**

--- a/src/service/VolunteerService.hx
+++ b/src/service/VolunteerService.hx
@@ -123,49 +123,23 @@ class VolunteerService
 		}			
 	}
 
-	public static function removeUserFromRole(user: db.User, multidistrib: db.MultiDistrib, role: db.VolunteerRole, reason: String ) {
+	public static function removeUserFromRole(user: db.User, multidistrib: db.MultiDistrib, role: db.VolunteerRole) {
 
 		var t = sugoi.i18n.Locale.texts;
 		if ( user != null && multidistrib != null && role != null ) {
 
-			//Look for the volunteer for that user adn this role
 			var foundVolunteer = Lambda.find(multidistrib.getVolunteerForUser(user), function(v) return v.volunteerRole.id==role.id);
 			if ( foundVolunteer != null ) {
 
-				//Send notification email to either the coordinators or all the members depending on the current date
-				var mail = new Mail();
-				mail.setSender(App.current.getTheme().email.senderEmail, App.current.getTheme().name);
 				var now = Date.now();
 				var alertDate = DateTools.delta( multidistrib.distribStartDate, - 1000.0 * 60 * 60 * 24 * multidistrib.group.vacantVolunteerRolesMailDaysBeforeDutyPeriod );
 
-				if ( now.getTime() <=  alertDate.getTime() ) {
-
-					//Recipients are the coordinators
-					var rights = if(foundVolunteer.volunteerRole.catalog==null){
-						[ Right.GroupAdmin ];
-					}else{
-						[ Right.ContractAdmin(foundVolunteer.volunteerRole.catalog.id) ];
-					}
-					var adminUsers = service.GroupService.getGroupMembersWithRights( multidistrib.group, rights );
-					for ( admin in adminUsers ) {
-						try {
-							mail.addRecipient( admin.email, admin.getName() );
-						} catch (e:Dynamic) {
-							trace('Invalid email for admin ${admin.getName()}: ${admin.email}');
-						}
-						if ( admin.email2 != null ) {
-							try {
-								mail.addRecipient( admin.email2 );
-							} catch (e:Dynamic) {
-								trace('Invalid email2 for admin ${admin.getName()}: ${admin.email2}');
-							}
-						}
-					}
-				}else{
-
-					var members = Lambda.array( multidistrib.group.getMembers() );
-					//Recipients are all members
-					for ( member in members ) {
+				// Only notify members if the "vacant roles" scheduled mail has already been sent.
+				// Before that date the upcoming cron mail will cover the vacancy.
+				if ( now.getTime() > alertDate.getTime() ) {
+					var mail = new Mail();
+					mail.setSender(App.current.getTheme().email.senderEmail, App.current.getTheme().name);
+					for ( member in Lambda.array(multidistrib.group.getMembers()) ) {
 						try {
 							mail.addRecipient( member.email, member.getName() );
 						} catch (e:Dynamic) {
@@ -179,23 +153,21 @@ class VolunteerService
 							}
 						}
 					}
+					var date = Formatting.hDate(multidistrib.distribStartDate, true);
+					mail.setSubject( t._( "A role has been left for ::date:: distribution", {date:date}) );
+					var html = App.current.processTemplate("mail/volunteerUnsuscribed.mtt", { fullname : user.getName(), role : role.name, group: multidistrib.group } );
+					mail.setHtmlBody( html );
+					App.sendMail(mail, multidistrib.group);
 				}
-				var date = Formatting.hDate(multidistrib.distribStartDate, true);
-				var subject = t._( "A role has been left for ::date:: distribution",{date:date});
-				mail.setSubject( subject );
-				var html = App.current.processTemplate("mail/volunteerUnsuscribed.mtt", { fullname : user.getName(), role : role.name, reason : reason, group: multidistrib.group  } );
-				mail.setHtmlBody( html );
-				App.sendMail(mail, multidistrib.group);
 
-				//delete assignment
 				foundVolunteer.lock();
 				foundVolunteer.delete();
-			} else {				
-				throw new Error(t._("This user is not assigned to this role!"));				
+			} else {
+				throw new Error(t._("This user is not assigned to this role!"));
 			}
 		} else {
 			throw new Error(t._("Missing distribution or role in the url!"));
-		}			
+		}
 	}
 
 	/**

--- a/www/lang/allTexts.pot
+++ b/www/lang/allTexts.pot
@@ -1849,8 +1849,8 @@ msgstr ""
 msgid "Be careful, this link is valid only 24 hours for security reasons."
 msgstr ""
 
-#: ../lang/master/tpl/mail/volunteerUnsuscribed.mtt:49
-msgid "<b>::fullname::</b> has left the role <b>::role::</b> for the following reason:"
+#: ../lang/master/tpl/mail/volunteerUnsuscribed.mtt:4
+msgid "<b>::fullname::</b> has left the role <b>::role::</b>."
 msgstr ""
 
 #: ../lang/master/tpl/mail/volunteerUnsuscribed.mtt:219

--- a/www/lang/texts_fr.po
+++ b/www/lang/texts_fr.po
@@ -3041,13 +3041,9 @@ msgstr ""
 "Vous pouvez utiliser les courriels suivants pour vous connecter à votre "
 "compte : <b>::emails::</b>"
 
-#: ../lang/master/tpl/mail/volunteerUnsuscribed.mtt:52
-msgid ""
-"<b>::fullname::</b> has left the role <b>::role::</b> for the following "
-"reason:"
-msgstr ""
-"<b>::fullname::</b> s'est désisté pour le rôle <b>::role::</b> et a indiqué "
-"la raison suivante :"
+#: ../lang/master/tpl/mail/volunteerUnsuscribed.mtt:4
+msgid "<b>::fullname::</b> has left the role <b>::role::</b>."
+msgstr "<b>::fullname::</b> s'est désisté du rôle <b>::role::</b>."
 
 #: ../lang/master/tpl/mail/volunteerUnsuscribed.mtt:228
 msgid "This role needs to be assigned to another person."


### PR DESCRIPTION
## Contexte

Deux problèmes liés sur le flux de désinscription d'un bénévole à une permanence :

- **mantis-330** : la page `/distribution/unsubscribeFromRole` imposait la saisie
  d'un motif envoyé à tous les membres du groupe, créant une friction inutile.
- **mantis-331** : le mail de désinscription était envoyé systématiquement, même
  quand le rappel des rôles vacants (cron) n'avait pas encore été déclenché —
  rendant la notification redondante et prématurée.

## Solution

### camap-hx

**`controller/Distribution.hx`**
- `doUnsubscribeFromRole` redirige vers `/distribution/volunteersCalendar`
  (URL legacy conservée pour compatibilité).

**`controller/api/Distributions.hx`**
- Nouvel endpoint `POST /api/distributions/unsubscribeFromRole/{distribId}/{roleId}` :
  effectue la désinscription sans motif requis.

**`service/VolunteerService.hx`**
- `removeUserFromRole` : suppression du paramètre `reason`.
- Nouvelle condition d'envoi du mail : uniquement si `now > alertDate`
  (c.-à-d. après la date à laquelle le cron « rôles vacants » se déclenche).
  Avant cette date, pas d'envoi — le cron prendra le relais.
- Simplification : un seul jeu de destinataires (tous les membres).

**`lang/master/tpl/mail/volunteerUnsuscribed.mtt`**
- Suppression du paragraphe « a indiqué la raison suivante ».
- Nouveau libellé : « **[Nom]** s'est désisté(e) du rôle **[Rôle]**. »

### camap-ts

**`modules/volunteersCalendar/requests.tsx`**
- Hook `useRestUnsubscribeFromRole` (appel REST POST).

**`modules/volunteersCalendar/components/VolunteersCalendarDistributionRole.tsx`**
- Le bouton « Se désinscrire » ouvre une Dialog MUI de confirmation
  (titre : « Permanence [rôle] du [date] », boutons Oui / Annuler)
  au lieu de naviguer vers la page Haxe supprimée.

**`modules/volunteersCalendar/VolunteersCalendar.module.tsx`**
- Passage de `roleName` et d'un callback `onUnsubscribeSuccess`
  (reset état + re-fetch du calendrier).

**`public/locales/fr/volunteers-calendar.json`**
- Clés de traduction pour la Dialog (`unsubscribeDialogTitle`,
  `unsubscribeDialogMessage`, `yes`, `cancel`).

## Comment tester

1. Se connecter en tant que bénévole inscrit à une permanence.
2. Ouvrir `/distribution/volunteersCalendar`.
3. Cliquer « Se désinscrire » → vérifier l'affichage de la Dialog avec le bon rôle et la bonne date.
4. « Annuler » → la Dialog se ferme, rien ne change.
5. « Oui » → désinscription effectuée, calendrier rafraîchi.
6. Accéder à `/distribution/unsubscribeFromRole/{id}/{id}` → redirection vers le calendrier.

**Mail — cas 1 (désinscription avant la date d'alerte)**
- Permanence dans 10 jours, `vacantVolunteerRolesMailDaysBeforeDutyPeriod = 7`
- Se désinscrire → aucun mail envoyé.

**Mail — cas 2 (désinscription après la date d'alerte)**
- Permanence dans 5 jours → mail envoyé à tous les membres, sans mention de raison.

## Checklist

- [x] Branches créées depuis `staging`
- [x] Code compile sans erreur (tsc --noEmit)
- [x] Fonctionnalités existantes non régressées
- [x] Titre de PR explicite

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>