### PR TITLE
[mantis-348] Numéroter les commandes par distribution plutôt que par panier

### DIFF
--- a/lang/master/tpl/contractadmin/orders.mtt
+++ b/lang/master/tpl/contractadmin/orders.mtt
@@ -78,7 +78,7 @@
 				<tr class="darkhead">
 					<td colspan="7">
 						<div class="basketNumber" ::cond basket!=null:: >
-							<i class="fa fa-shopping-basket" aria-hidden="true"></i> N°::basket.num::
+							<i class="fa fa-shopping-basket" aria-hidden="true"></i> N°::orderRank.get(basket.id)::
 						</div>
 
 						<a href="/member/view/::basket.userId::" target="_blank">::basket._user.getName()::</a>

--- a/lang/master/tpl/contractadmin/orders.mtt
+++ b/lang/master/tpl/contractadmin/orders.mtt
@@ -53,6 +53,17 @@
 			onclick="toggleQtInput()" id="setWeightsButton">
 			<i class="icon icon-balance"></i> <span class="orderQtInput">::_("Set weights after weighing")::</span><span class="orderQtText hidden">::_("Stop editing weights")::</span>
 		</button>
+
+		<div class="btn-group" role="group" style="display:inline-block;">
+			<a href="/contractAdmin/orders/::catalog.id::?d=::distribution.id::&sort=name"
+				class="btn btn-default btn-sm ::if(sortBy=='name')::active::end::">
+				::_("Sort by name")::
+			</a>
+			<a href="/contractAdmin/orders/::catalog.id::?d=::distribution.id::&sort=num"
+				class="btn btn-default btn-sm ::if(sortBy=='num')::active::end::">
+				::_("Sort by order N°")::
+			</a>
+		</div>
 	</div>
 
 	::if disabledProducts > 0::
@@ -69,7 +80,7 @@
 	td.userRow a{ color:white; }
 	</style>
 
-		::foreach basket distribution._multiDistrib.getBaskets()::
+		::foreach basket baskets::
 			::set total = 0::
 			::set distribOrders = prepare(basket.getDistributionOrders(distribution))::
 			::if (distribOrders.length > 0 )::

--- a/src/controller/ContractAdmin.hx
+++ b/src/controller/ContractAdmin.hx
@@ -663,7 +663,7 @@ class ContractAdmin extends Controller {
 	 * Overview of orders for this contract in backoffice
 	 */
 	@tpl("contractadmin/orders.mtt")
-	function doOrders(catalog:db.Catalog, ?args:{d:db.Distribution, ?delete:db.UserOrder}) {
+	function doOrders(catalog:db.Catalog, ?args:{d:db.Distribution, ?delete:db.UserOrder, ?sort:String}) {
 		view.nav.push("orders");
 		sendNav(catalog);
 
@@ -704,6 +704,21 @@ class ContractAdmin extends Controller {
 			rank++;
 		}
 		view.orderRank = orderRank;
+
+		// Tri des paniers : par nom (défaut, historique) ou par rang de commande
+		var sortBy = args.sort == "num" ? "num" : "name";
+		var baskets = args.d.multiDistrib.getBaskets();
+		if (sortBy == "num") {
+			baskets.sort(function(a, b) {
+				var ra = orderRank.get(a.id);
+				var rb = orderRank.get(b.id);
+				if (ra == null) ra = 999999;
+				if (rb == null) rb = 999999;
+				return ra - rb;
+			});
+		}
+		view.baskets = baskets;
+		view.sortBy = sortBy;
 
 		if (App.current.params.get("csv") == "1") {
 			var data = [];

--- a/src/controller/ContractAdmin.hx
+++ b/src/controller/ContractAdmin.hx
@@ -691,6 +691,20 @@ class ContractAdmin extends Controller {
 		view.multiDistribId = args.d.multiDistrib.id;
 		view.c = view.catalog = catalog;
 
+		// Rang de passage de commande pour cette distribution (ce catalogue, cette date),
+		// basé sur la première ligne de commande de chaque panier (min(id), stable même après
+		// modification de quantité). Utilisé pour prioriser les commandes en cas de stock insuffisant.
+		var orderRank = new Map<Int, Int>();
+		var rankRows = sys.db.Manager.cnx.request("select basketId, min(id) as firstOrderId from UserOrder "
+			+ "where distributionId=" + args.d.id + " and basketId is not null "
+			+ "group by basketId order by firstOrderId").results();
+		var rank = 1;
+		for (r in rankRows) {
+			orderRank.set(r.basketId, rank);
+			rank++;
+		}
+		view.orderRank = orderRank;
+
 		if (App.current.params.get("csv") == "1") {
 			var data = [];
 			for (basket in args.d.multiDistrib.getBaskets()) {

--- a/www/lang/texts_fr.po
+++ b/www/lang/texts_fr.po
@@ -2322,6 +2322,14 @@ msgstr "Par produit-membre"
 msgid "Set weights after weighing"
 msgstr "Saisie des poids après pesée"
 
+#: ../lang/master/tpl/contractadmin/orders.mtt:2382
+msgid "Sort by name"
+msgstr "Trier par nom"
+
+#: ../lang/master/tpl/contractadmin/orders.mtt:2386
+msgid "Sort by order N°"
+msgstr "Trier par n° de commande"
+
 #: ../lang/master/tpl/contractadmin/orders.mtt:2445
 msgid "Stop editing weights"
 msgstr "Terminer la saisie"


### PR DESCRIPTION
## Contexte

Sur la page Commandes d'une distribution (`contractAdmin/orders`), le N°
affiché à côté de chaque adhérent correspond à `Basket.num` : un rang
attribué une seule fois, lors de la première commande de l'utilisateur
sur le `multiDistrib` (le jour de distribution, qui peut regrouper
plusieurs producteurs/catalogues). Ce numéro ne correspond donc pas à
l'ordre de passage des commandes pour le catalogue et la date affichés,
ce qui empêchait de s'en servir pour prioriser les commandes en cas de
stock insuffisant (cf. ticket mantis-348).

## Solution

- `ContractAdmin.hx` (`doOrders`) : calcule un rang par panier à partir
  des `UserOrder` de la distribution consultée (`distributionId`), trié
  par `min(id)` (stable même si la quantité d'une ligne est modifiée
  ensuite via le champ inline).
- `orders.mtt` : affiche ce rang à la place de `basket.num`, et ajoute
  deux boutons de tri ("Trier par nom" / "Trier par n° de commande")
  contrôlés par un nouveau paramètre d'URL `?sort=num|name` (`name` reste
  le comportement par défaut, inchangé).

`Basket.num` n'est pas modifié : il est utilisé sur plusieurs autres
pages (feuilles d'émargement `distribution/list*.mtt`,
`listByProductUser.mtt`) où il garde son sens actuel (numéro de panier
pour le jour de distribution, tous producteurs confondus).

## Limite connue

Si une quantité déjà commandée est modifiée via la fenêtre modale
"Nouvelle commande" (et non le champ inline du tableau), la ligne
`UserOrder` correspondante est supprimée et recréée avec un nouvel id
(fusion de quantité dans `OrderService.create()`). Si c'était la ligne
la plus ancienne du panier pour cette distribution, son rang affiché
peut alors reculer. Cas marginal, non traité dans cette PR.

## Comment tester

1. Ouvrir `contractAdmin/orders/<catalogId>?d=<distributionId>` pour une
   distribution ayant plusieurs commandes.
2. Vérifier que le N° affiché (tri par défaut, par nom) suit l'ordre
   chronologique de première commande des adhérents sur *cette*
   distribution (comparer avec `min(id)` dans `UserOrder` pour ce
   `distributionId`).
3. Cliquer sur "Trier par n° de commande" (`?sort=num`) et vérifier que
   les paniers s'affichent dans l'ordre croissant de ce numéro.
4. Vérifier qu'une modification de quantité sur une ligne existante via
   le champ inline ne change pas le rang affiché.
5. Vérifier que les feuilles d'émargement (`distribution/list`,
   `listByDate`, `listByProductUser`) affichent toujours le même
   `Basket.num` qu'avant (non régressé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>